### PR TITLE
Switch home page redirect to use `home_url()`

### DIFF
--- a/wp-oauth.php
+++ b/wp-oauth.php
@@ -22,7 +22,7 @@ Class WPOA {
 
 	// set a version that we can use for performing plugin updates, this should always match the plugin version:
 	const PLUGIN_VERSION = "0.4";
-	
+
 	// singleton class pattern:
 	protected static $instance = NULL;
 	public static function get_instance() {
@@ -112,7 +112,7 @@ Class WPOA {
 		'wpoa_restore_default_settings' => 0,							// 0, 1
 		'wpoa_delete_settings_on_uninstall' => 0,						// 0, 1
 	);
-	
+
 	// when the plugin class gets created, fire the initialization:
 	function __construct() {
 		// hook activation and deactivation for the plugin:
@@ -123,7 +123,7 @@ Class WPOA {
 		// hook init event to handle plugin initialization:
 		add_action('init', array($this, 'init'));
 	}
-	
+
 	// a wrapper for wordpress' get_option(), this basically feeds get_option() the setting's correct default value as specified at the top of this file:
 	/*
 	function wpoa_option($name) {
@@ -132,15 +132,15 @@ Class WPOA {
 		return $val;
 	}
 	*/
-	
+
 	// do something during plugin activation:
 	function wpoa_activate() {
 	}
-	
+
 	// do something during plugin deactivation:
 	function wpoa_deactivate() {
 	}
-	
+
 	// do something during plugin update:
 	function wpoa_update() {
 		$plugin_version = WPOA::PLUGIN_VERSION;
@@ -155,7 +155,7 @@ Class WPOA {
 			add_action('admin_notices', array($this, 'wpoa_update_notice'));
 		}
 	}
-	
+
 	// indicate to the admin that the plugin has been updated:
 	function wpoa_update_notice() {
 		$settings_link = "<a href='options-general.php?page=WP-OAuth.php'>Settings Page</a>"; // CASE SeNsItIvE filename!
@@ -165,7 +165,7 @@ Class WPOA {
 		</div>
 		<?php
 	}
-	
+
 	// adds any missing settings and their default values:
 	function wpoa_add_missing_settings() {
 		foreach($this->settings as $setting_name => $default_value) {
@@ -176,7 +176,7 @@ Class WPOA {
 			$added = add_option($setting_name, $default_value);
 		}
 	}
-	
+
 	// restores the default plugin settings:
 	function wpoa_restore_default_settings() {
 		foreach($this->settings as $setting_name => $default_value) {
@@ -188,7 +188,7 @@ Class WPOA {
 		}
 		add_action('admin_notices', array($this, 'wpoa_restore_default_settings_notice'));
 	}
-	
+
 	// indicate to the admin that the plugin has been updated:
 	function wpoa_restore_default_settings_notice() {
 		$settings_link = "<a href='options-general.php?page=WP-OAuth.php'>Settings Page</a>"; // CASE SeNsItIvE filename!
@@ -234,7 +234,7 @@ Class WPOA {
 			add_filter('login_footer', array($this, 'wpoa_push_login_messages'));
 		}
 	}
-	
+
 	// init scripts and styles for use on FRONTEND PAGES:
 	function wpoa_init_frontend_scripts_styles() {
 		// here we "localize" php variables, making them available as a js variable in the browser:
@@ -260,7 +260,7 @@ Class WPOA {
 		wp_enqueue_script('wpoa-script', plugin_dir_url( __FILE__ ) . 'wp-oauth.js', array());
 		wp_enqueue_style('wpoa-style', plugin_dir_url( __FILE__ ) . 'wp-oauth.css', array());
 	}
-	
+
 	// init scripts and styles for use on BACKEND PAGES:
 	function wpoa_init_backend_scripts_styles() {
 		// here we "localize" php variables, making them available as a js variable in the browser:
@@ -287,7 +287,7 @@ Class WPOA {
 		// load the default wordpress media screen:
 		wp_enqueue_media();
 	}
-	
+
 	// init scripts and styles for use on the LOGIN PAGE:
 	function wpoa_init_login_scripts_styles() {
 		// here we "localize" php variables, making them available as a js variable in the browser:
@@ -316,25 +316,25 @@ Class WPOA {
 		wp_enqueue_script('wpoa-script', plugin_dir_url( __FILE__ ) . 'wp-oauth.js', array());
 		wp_enqueue_style('wpoa-style', plugin_dir_url( __FILE__ ) . 'wp-oauth.css', array());
 	}
-	
+
 	// add a settings link to the plugins page:
 	function wpoa_settings_link($links) {
 		$settings_link = "<a href='options-general.php?page=WP-OAuth.php'>Settings</a>"; // CASE SeNsItIvE filename!
-		array_unshift($links, $settings_link); 
-		return $links; 
+		array_unshift($links, $settings_link);
+		return $links;
 	}
-	
+
 	// ===============
 	// GENERIC HELPERS
 	// ===============
-	
+
 	// adds basic http auth to a given url string:
 	function wpoa_add_basic_auth($url, $username, $password) {
 		$url = str_replace("https://", "", $url);
 		$url = "https://" . $username . ":" . $password . "@" . $url;
 		return $url;
 	}
-	
+
 	// ===================
 	// LOGIN FLOW HANDLING
 	// ===================
@@ -347,7 +347,7 @@ Class WPOA {
 		$vars[] = 'error_message';
 		return $vars;
 	}
-	
+
 	// handle the querystring triggers:
 	function wpoa_qvar_handlers() {
 		if (get_query_var('connect')) {
@@ -363,7 +363,7 @@ Class WPOA {
 			$this->wpoa_include_connector($provider);
 		}
 	}
-	
+
 	// load the provider script that is being requested by the user or being called back after authentication:
 	function wpoa_include_connector($provider) {
 		// normalize the provider name (no caps, no spaces):
@@ -373,7 +373,7 @@ Class WPOA {
 		// include the provider script:
 		include 'login-' . $provider . '.php';
 	}
-	
+
 	// =======================
 	// LOGIN / LOGOUT HANDLING
 	// =======================
@@ -389,7 +389,7 @@ Class WPOA {
 		$user = get_user_by('id', $query_result);
 		return $user;
 	}
-	
+
 	// login (or register and login) a wordpress user based on their oauth identity:
 	function wpoa_login_user($oauth_identity) {
 		// store the user info in the user session so we can grab it later if we need to register the user:
@@ -425,7 +425,7 @@ Class WPOA {
 		// we shouldn't be here, but just in case...
 		$this->wpoa_end_login("Sorry, we couldn't log you in. The login flow terminated in an unexpected way. Please notify the admin or try again later.");
 	}
-	
+
 	// ends the login request by clearing the login state and redirecting the user to the desired page:
 	function wpoa_end_login($msg) {
 		$last_url = $_SESSION["WPOA"]["LAST_URL"];
@@ -436,7 +436,7 @@ Class WPOA {
 		$redirect_url = "";
 		switch ($redirect_method) {
 			case "home_page":
-				$redirect_url = site_url();
+				$redirect_url = home_url();
 				break;
 			case "last_page":
 				$redirect_url = $last_url;
@@ -458,7 +458,7 @@ Class WPOA {
 		wp_safe_redirect($redirect_url);
 		die();
 	}
-	
+
 	// logout the wordpress user:
 	// TODO: this is usually called from a custom logout button, but we could have the button call /wp-logout.php?action=logout for more consistency...
 	function wpoa_logout_user() {
@@ -467,7 +467,7 @@ Class WPOA {
 		session_destroy(); 	// destroy the php user session
 		wp_logout(); 		// logout the wordpress user...this gets hooked and diverted to wpoa_end_logout() for final handling
 	}
-	
+
 	// ends the logout request by redirecting the user to the desired page:
 	function wpoa_end_logout() {
 		$_SESSION["WPOA"]["RESULT"] = 'Logged out successfully.';
@@ -487,7 +487,7 @@ Class WPOA {
 			case "default_handling":
 				return false;
 			case "home_page":
-				$redirect_url = site_url();
+				$redirect_url = home_url();
 				break;
 			case "last_page":
 				$redirect_url = $last_url;
@@ -509,7 +509,7 @@ Class WPOA {
 		wp_safe_redirect($redirect_url);
 		die();
 	}
-	
+
 	// links a third-party account to an existing wordpress user account:
 	function wpoa_link_account($user_id) {
 		if ($_SESSION['WPOA']['USER_ID'] != '') {
@@ -540,14 +540,14 @@ Class WPOA {
 		// wp-ajax requires death:
 		die();
 	}
-	
+
 	// pushes login messages into the dom where they can be extracted by javascript:
 	function wpoa_push_login_messages() {
 		$result = $_SESSION['WPOA']['RESULT'];
 		$_SESSION['WPOA']['RESULT'] = '';
 		echo "<div id='wpoa-result'>" . $result . "</div>";
 	}
-	
+
 	// clears the login state:
 	function wpoa_clear_login_state() {
 		unset($_SESSION["WPOA"]["USER_ID"]);
@@ -557,7 +557,7 @@ Class WPOA {
 		unset($_SESSION["WPOA"]["EXPIRES_AT"]);
 		//unset($_SESSION["WPOA"]["LAST_URL"]);
 	}
-	
+
 	// ===================================
 	// DEFAULT LOGIN SCREEN CUSTOMIZATIONS
 	// ===================================
@@ -566,7 +566,7 @@ Class WPOA {
 	function wpoa_logo_link() {
 		return get_bloginfo('url');
 	}
-	
+
 	// show a custom login form on the default login screen:
 	function wpoa_customize_login_screen() {
 		$html = "";
@@ -581,7 +581,7 @@ Class WPOA {
 	// ===================================
 	// DEFAULT COMMENT FORM CUSTOMIZATIONS
 	// ===================================
-	
+
 	// show a custom login form at the top of the default comment form:
 	function wpoa_customize_comment_form_fields($fields) {
 		$html = "";
@@ -593,7 +593,7 @@ Class WPOA {
 		}
 		return $fields;
 	}
-	
+
 	// show a custom login form at the top of the default comment form:
 	function wpoa_customize_comment_form() {
 		$html = "";
@@ -608,7 +608,7 @@ Class WPOA {
 	// =========================
 	// LOGIN / LOGOUT COMPONENTS
 	// =========================
-	
+
 	// shortcode which allows adding the wpoa login form to any post or page:
 	function wpoa_login_form( $atts ){
 		$a = shortcode_atts( array(
@@ -633,7 +633,7 @@ Class WPOA {
 		$html = $this->wpoa_login_form_content($a['design'], $a['icon_set'], $a['layout'], $a['button_prefix'], $a['align'], $a['show_login'], $a['show_logout'], $a['logged_out_title'], $a['logged_in_title'], $a['logging_in_title'], $a['logging_out_title'], $a['style'], $a['class']);
 		return $html;
 	}
-	
+
 	// gets the content to be used for displaying the login/logout form:
 	function wpoa_login_form_content($design = '', $icon_set = 'icon_set', $layout = 'links-column', $button_prefix = '', $align = 'left', $show_login = 'conditional', $show_logout = 'conditional', $logged_out_title = 'Please login:', $logged_in_title = 'You are already logged in.', $logging_in_title = 'Logging in...', $logging_out_title = 'Logging out...', $style = '', $class = '') { // even though wpoa_login_form() will pass a default, we might call this function from another method so it's important to re-specify the default values
 		// if a design was specified and that design exists, load the shortcode attributes from that design:
@@ -682,7 +682,7 @@ Class WPOA {
 		$html .= "</div>";
 		return $html;
 	}
-	
+
 	// generate and return the login buttons, depending on available providers:
 	function wpoa_login_buttons($icon_set, $button_prefix) {
 		// generate the atts once (cache them), so we can use it for all buttons without computing them each time:
@@ -729,7 +729,7 @@ Class WPOA {
 		}
 		return $html;
 	}
-	
+
 	// output the custom login form design selector:
 	function wpoa_login_form_designs_selector($id = '', $master = false) {
 		$html = "";
@@ -753,7 +753,7 @@ Class WPOA {
 		}
 		return $html;
 	}
-	
+
 	// returns a saved login form design as a shortcode atts string or array for direct use via the shortcode
 	function wpoa_get_login_form_design($design_name, $as_string = false) {
 		$designs_json = get_option('wpoa_login_form_designs');
@@ -776,7 +776,7 @@ Class WPOA {
 		}
 		return $atts;
 	}
-	
+
 	function wpoa_login_form_design_exists($design_name) {
 		$designs_json = get_option('wpoa_login_form_designs');
 		$designs_array = json_decode($designs_json, true);
@@ -793,7 +793,7 @@ Class WPOA {
 			return false;
 		}
 	}
-	
+
 	// shows the user's linked providers, used on the 'Your Profile' page:
 	function wpoa_linked_accounts() {
 		// get the current user:
@@ -841,18 +841,18 @@ Class WPOA {
 		echo "</td>";
 		echo "</table>";
 	}
-	
+
 	// ====================
 	// PLUGIN SETTINGS PAGE
 	// ====================
-	
+
 	// registers all settings that have been defined at the top of the plugin:
 	function wpoa_register_settings() {
 		foreach ($this->settings as $setting_name => $default_value) {
 			register_setting('wpoa_settings', $setting_name);
 		}
 	}
-	
+
 	// add the main settings page:
 	function wpoa_settings_page() {
 		add_options_page( 'WP-OAuth Options', 'WP-OAuth', 'manage_options', 'WP-OAuth', array($this, 'wpoa_settings_page_content') );


### PR DESCRIPTION
As site `site_url()` redirects the user to the WordPress address
eg `example.co.uk/wordpress` it may not always be the home page
when the site address is different to the WordPress install directory
eg `example.co.uk`.
